### PR TITLE
Dockerfile documentation: .gradle volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@
 # Run with (e.g. `buildozer --version`):
 # docker run \
 #   --volume "$HOME/.buildozer":/home/user/.buildozer \
+#   --volume "$HOME/.gradle":/home/user/.gradle \
 #   --volume "$PWD":/home/user/hostcwd \
 #   kivy/buildozer --version
 #
 # Or for interactive shell:
 # docker run --interactive --tty --rm \
 #   --volume "$HOME/.buildozer":/home/user/.buildozer \
+#   --volume "$HOME/.gradle":/home/user/.gradle \
 #   --volume "$PWD":/home/user/hostcwd \
 #   --entrypoint /bin/bash \
 #   kivy/buildozer


### PR DESCRIPTION
Add #   --volume "$HOME/.gradle":/home/user/.gradle \ to the documentation at the beginning of the Dockerfile
This avoid download and setup gradle at each run